### PR TITLE
Fix module issue in CI

### DIFF
--- a/.github/workflows/scheduled_update.yaml
+++ b/.github/workflows/scheduled_update.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           cache: 'pip'
+          python-version: '3.13'
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/index.json
+++ b/index.json
@@ -1050,6 +1050,18 @@
     "rank": "normal"
   },
   {
+    "key": "Key:INEGI:cve_loc",
+    "url": "https://www.inegi.org.mx/app/areasgeograficas/?ag=$1",
+    "source": "wikidata:P1630",
+    "rank": "normal"
+  },
+  {
+    "key": "Key:INEGI:MUNID",
+    "url": "https://www.inegi.org.mx/app/areasgeograficas/?ag=$1",
+    "source": "wikidata:P1630",
+    "rank": "normal"
+  },
+  {
     "key": "Key:instagram",
     "url": "https://www.instagram.com/$1/",
     "source": "wikidata:P1630",
@@ -1308,6 +1320,12 @@
     "rank": "normal"
   },
   {
+    "key": "Key:protection_title:wikidata",
+    "url": "https://www.wikidata.org/entity/$1",
+    "source": "osmwiki:P8",
+    "rank": "normal"
+  },
+  {
     "key": "Key:railway:wikipedia",
     "url": "https://wikipedia.org/wiki/$1",
     "source": "osmwiki:P8",
@@ -1474,6 +1492,12 @@
     "url": "http://www.marina.difesa.it/cosa-facciamo/per-la-difesa-sicurezza/fari/Pagine/$1.aspx",
     "source": "wikidata:P1630",
     "rank": "preferred"
+  },
+  {
+    "key": "Key:ref:EGID",
+    "url": "https://api.geo.admin.ch/rest/services/ech/MapServer/ch.bfs.gebaeude_wohnungs_register/$1_0/extendedHtmlPopup",
+    "source": "wikidata:P1630",
+    "rank": "normal"
   },
   {
     "key": "Key:ref:EU:bwid",
@@ -1848,6 +1872,12 @@
     "rank": "normal"
   },
   {
+    "key": "Key:ref:IL:inature",
+    "url": "https://www.inature.info/wiki/$1",
+    "source": "osmwiki:P8",
+    "rank": "normal"
+  },
+  {
     "key": "Key:ref:INEP",
     "url": "https://culturaeduca.cc/equipamento/escola_detalhe/$1",
     "source": "osmwiki:P8",
@@ -1927,7 +1957,7 @@
   },
   {
     "key": "Key:ref:isil",
-    "url": "http://sigel.staatsbibliothek-berlin.de/nc/suche/?isil=$1",
+    "url": "http://sigel.staatsbibliothek-berlin.de/suche/?isil=$1",
     "source": "wikidata:P1630",
     "rank": "normal"
   },
@@ -1971,6 +2001,24 @@
     "key": "Key:ref:isil",
     "url": "https://wikidata-externalid-url.toolforge.org/?url=http%3A%2F%2Fwww.sudoc.abes.fr%2Fcbs%2Fxslt%2F%2FDB%3D2.2%2FCMD%3FACT%3DSRCHA%26IKT%3D8888%26SRT%3DRLV%26TRM%3D%251&exp=%5EFR-(%5Cd%7B9%7D)&id=$1",
     "source": "wikidata:P1630",
+    "rank": "normal"
+  },
+  {
+    "key": "Key:ref:KGS-PBC",
+    "url": "https://wikidata-externalid-url.toolforge.org/?url=https%3A%2F%2Fheritage.toolforge.org%2Fapi%2Fapi.php%3Faction%3Dsearch%26format%3Dhtml%26srcountry%3Dch%26srid%3D%251&exp=0*(.*)&id=$1",
+    "source": "wikidata:P1630",
+    "rank": "preferred"
+  },
+  {
+    "key": "Key:ref:KGS-PBC",
+    "url": "https://heritage.toolforge.org/api/api.php?action=search&format=html&srcountry=ch&srid=$1",
+    "source": "wikidata:P1630",
+    "rank": "normal"
+  },
+  {
+    "key": "Key:ref:KGS-PBC",
+    "url": "https://heritage.toolforge.org/api/api.php?action=search&format=html&srcountry=ch&srid=$1",
+    "source": "wikidata:P3303",
     "rank": "normal"
   },
   {
@@ -2130,6 +2178,12 @@
     "rank": "preferred"
   },
   {
+    "key": "Key:ref:sandre",
+    "url": "https://id.eaufrance.fr/SysTraitementEauxUsees/$1",
+    "source": "wikidata:P1630",
+    "rank": "normal"
+  },
+  {
     "key": "Key:ref:UAI",
     "url": "http://bibliotheques.enseignementsup-recherche.gouv.fr/FR/annuaire/siege/$1/",
     "source": "wikidata:P3303",
@@ -2157,6 +2211,12 @@
     "key": "Key:ref:UAI",
     "url": "https://www.journaldesfemmes.fr/maman/ecole/etablissement-$1",
     "source": "wikidata:P3303",
+    "rank": "normal"
+  },
+  {
+    "key": "Key:ref:US-MA:mhc",
+    "url": "https://mhc-macris.net/details?mhcid=$1",
+    "source": "wikidata:P1630",
     "rank": "normal"
   },
   {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tag2link",
-  "version": "2024.8.21",
+  "version": "2024.10.21",
   "description": "Formatter URLs for OpenStreetMap tags",
   "keywords": [
     "openstreetmap",

--- a/taginfo.json
+++ b/taginfo.json
@@ -1,10 +1,10 @@
 {
   "data_format": 1,
-  "data_updated": "20240821T160000Z",
+  "data_updated": "20241021T160000Z",
   "project": {
     "name": "tag2link",
     "description": "Formatter URLs for OpenStreetMap tags",
-    "project_url": "https://github.com/osmlab/tag2link",
+    "project_url": "https://github.com/JOSM/tag2link",
     "contact_name": "Simon Legner",
     "contact_email": "Simon.Legner@gmail.com"
   },
@@ -710,6 +710,14 @@
       "description": "https://www.radarbox.com/data/airports/$1"
     },
     {
+      "key": "INEGI:cve_loc",
+      "description": "https://www.inegi.org.mx/app/areasgeograficas/?ag=$1"
+    },
+    {
+      "key": "INEGI:MUNID",
+      "description": "https://www.inegi.org.mx/app/areasgeograficas/?ag=$1"
+    },
+    {
       "key": "instagram",
       "description": "https://www.instagram.com/$1/"
     },
@@ -882,6 +890,10 @@
       "description": "$1"
     },
     {
+      "key": "protection_title:wikidata",
+      "description": "https://www.wikidata.org/entity/$1"
+    },
+    {
       "key": "railway:wikipedia",
       "description": "https://wikipedia.org/wiki/$1"
     },
@@ -992,6 +1004,10 @@
     {
       "key": "ref:ef",
       "description": "http://www.marina.difesa.it/cosa-facciamo/per-la-difesa-sicurezza/fari/Pagine/$1.aspx"
+    },
+    {
+      "key": "ref:EGID",
+      "description": "https://api.geo.admin.ch/rest/services/ech/MapServer/ch.bfs.gebaeude_wohnungs_register/$1_0/extendedHtmlPopup"
     },
     {
       "key": "ref:EU:bwid",
@@ -1242,6 +1258,10 @@
       "description": "https://www.fahrplanauskunft-mv.de/vmvsl3plus/departureMonitor?formik=origin%3D$1&lng=en"
     },
     {
+      "key": "ref:IL:inature",
+      "description": "https://www.inature.info/wiki/$1"
+    },
+    {
       "key": "ref:INEP",
       "description": "https://culturaeduca.cc/equipamento/escola_detalhe/$1"
     },
@@ -1295,7 +1315,7 @@
     },
     {
       "key": "ref:isil",
-      "description": "http://sigel.staatsbibliothek-berlin.de/nc/suche/?isil=$1"
+      "description": "http://sigel.staatsbibliothek-berlin.de/suche/?isil=$1"
     },
     {
       "key": "ref:isil",
@@ -1324,6 +1344,18 @@
     {
       "key": "ref:isil",
       "description": "https://wikidata-externalid-url.toolforge.org/?url=http%3A%2F%2Fwww.sudoc.abes.fr%2Fcbs%2Fxslt%2F%2FDB%3D2.2%2FCMD%3FACT%3DSRCHA%26IKT%3D8888%26SRT%3DRLV%26TRM%3D%251&exp=%5EFR-(%5Cd%7B9%7D)&id=$1"
+    },
+    {
+      "key": "ref:KGS-PBC",
+      "description": "https://wikidata-externalid-url.toolforge.org/?url=https%3A%2F%2Fheritage.toolforge.org%2Fapi%2Fapi.php%3Faction%3Dsearch%26format%3Dhtml%26srcountry%3Dch%26srid%3D%251&exp=0*(.*)&id=$1"
+    },
+    {
+      "key": "ref:KGS-PBC",
+      "description": "https://heritage.toolforge.org/api/api.php?action=search&format=html&srcountry=ch&srid=$1"
+    },
+    {
+      "key": "ref:KGS-PBC",
+      "description": "https://heritage.toolforge.org/api/api.php?action=search&format=html&srcountry=ch&srid=$1"
     },
     {
       "key": "ref:kons",
@@ -1430,6 +1462,10 @@
       "description": "https://www.sandre.eaufrance.fr/geo/CoursEau_Carthage2017/$1"
     },
     {
+      "key": "ref:sandre",
+      "description": "https://id.eaufrance.fr/SysTraitementEauxUsees/$1"
+    },
+    {
       "key": "ref:UAI",
       "description": "http://bibliotheques.enseignementsup-recherche.gouv.fr/FR/annuaire/siege/$1/"
     },
@@ -1448,6 +1484,10 @@
     {
       "key": "ref:UAI",
       "description": "https://www.journaldesfemmes.fr/maman/ecole/etablissement-$1"
+    },
+    {
+      "key": "ref:US-MA:mhc",
+      "description": "https://mhc-macris.net/details?mhcid=$1"
     },
     {
       "key": "ref:US:EIA",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "Node16",
-    "moduleResolution": "node",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "sourceMap": true,
     "strictNullChecks": true
   }


### PR DESCRIPTION
```
(node:1808) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/home/runner/work/tag2link/tag2link/build.ts:2
import { isDeepStrictEqual } from "util";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at wrapSafe (node:internal/modules/cjs/loader:1378:20)
    at Module._compile (node:internal/modules/cjs/loader:1428:41)
    at Module.m._compile (/home/runner/work/tag2link/tag2link/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Object.require.extensions.<computed> [as .ts] (/home/runner/work/tag2link/tag2link/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1104:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at phase4 (/home/runner/work/tag2link/tag2link/node_modules/ts-node/src/bin.ts:649:14)
    at bootstrap (/home/runner/work/tag2link/tag2link/node_modules/ts-node/src/bin.ts:95:10)
```

The fix is to use `nodenext` for `moduleResolution`.