### PR TITLE
add TypeScript defintions

### DIFF
--- a/index.d.json.ts
+++ b/index.d.json.ts
@@ -1,0 +1,14 @@
+export interface Tag2Link {
+  /** OSM tag key */
+  key: `Key:${string}`;
+  /** URL template or formatter URL: replace `$1` with the tag value */
+  url: string;
+  /** Source of this formatter URL */
+  source: `${'wikidata' | 'osm'}:P${number}`;
+  /** Rank or relative importance of this formatter URL */
+  rank: 'preferred' | 'normal' | 'deprecated';
+}
+
+declare const exports: Tag2Link[];
+
+export default exports;

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "url-template"
   ],
   "main": "index.json",
+  "types": "index.d.json.ts",
   "scripts": {
     "build": "npx ts-node build.ts"
   },


### PR DESCRIPTION
This helpful for anyone importing [the npm package](http://npm.im/tag2link) from JavaScript or TypeScript.

Even people who don't use type-checking with still benefit, because IDEs will use these defintions to provide auto-complete suggestions. For example:

<img width="596" alt="image" src="https://github.com/user-attachments/assets/3e2b9114-de5c-4ea0-bc16-8b6006d16b0c" />

