### PR TITLE
handle new wikidata property P13786

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains formatter URLs for OpenStreetMap keys. The data is obtained from:
 
-- Wikidata items which have [OSM tag or key (P1282)](https://www.wikidata.org/wiki/Property:P1282) and [formatter URL (P1630)](https://www.wikidata.org/wiki/Property:P1630) defined
+- Wikidata items which have [OSM key (P13786)](https://www.wikidata.org/wiki/Property:P13786) and [formatter URL (P1630)](https://www.wikidata.org/wiki/Property:P1630) defined
 - OSM Wiki Wikibase via the OSM Sophox Service which have [formatter URL (P8)](https://wiki.openstreetmap.org/wiki/Property:P8)
 
 ## Contributing

--- a/tag2link.wikidata.sparql
+++ b/tag2link.wikidata.sparql
@@ -1,6 +1,7 @@
 SELECT ?OSM_key ?formatter_URL ?rank ?source WHERE {
-  { ?item wdt:P1282 ?OSM_key. }
-  FILTER(STRSTARTS(?OSM_key, 'Key:')) .
+  { ?item wdt:P13786 ?raw_OSM_key. } .
+
+  BIND(CONCAT("Key:", STR( ?raw_OSM_key )) AS ?OSM_key)
 
   {
     { ?item p:P1630 [ps:P1630 ?formatter_URL; wikibase:rank ?rank;]. BIND("wikidata:P1630" AS ?source ). }


### PR DESCRIPTION
yesterday wikidata [replaced](https://www.wikidata.org/wiki/Wikidata:Property_proposal/OpenStreetMap_key) their existing property [OpenStreetMap tag or key<sup><code>P1282</code></sup>](https://www.wikidata.org/wiki/Property:P1282) with two new properties:
* [OpenStreetMap tag<sup><code>P1282</code></sup>](https://www.wikidata.org/wiki/Property:P1282) – reusing the same ID as the old property
* [OpenStreetMap key<sup><code>P13786</code></sup>](https://www.wikidata.org/wiki/Property:P13786)

This breaks tag2link, because we need to search [`P13786`](https://www.wikidata.org/wiki/Property:P13786) instead of [`P1282`](https://www.wikidata.org/wiki/Property:P1282)


Tested by running the script locally.